### PR TITLE
Makes sure any dom-repeat element are not added. see GH issue 27 norefs

### DIFF
--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -208,6 +208,7 @@
 			return node.nodeType === Node.ELEMENT_NODE &&
 				node.getAttribute('slot') !== 'info' &&
 				node.tagName !== 'TEMPLATE' &&
+				node.tagName !== 'DOM-REPEAT' &&
 				node.getAttribute('slot') !== 'extra';
 		},
 


### PR DESCRIPTION
Ensures the dom-repeat is not itself added to menu item array. Tested and any potential "children", still seem to get picked up.