### PR TITLE
fix: undefined _layoutDebouncer

### DIFF
--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -202,7 +202,7 @@ class CosmozBottomBar extends mixinBehaviors([IronResizableBehavior], PolymerEle
 		this._nodeObserver.disconnect();
 		this._nodeObserverExtra.disconnect();
 		this._hiddenMutationObserver.disconnect();
-		this._layoutDebouncer.cancel();
+		this._layoutDebouncer?.cancel(); /* eslint-disable-line no-unused-expressions */
 	}
 
 	_canAddMoreButtonToBar(width, bottomBarElements, menuElements) {


### PR DESCRIPTION
`_layoutDebouncer` can be undefined if cosmoz-bottom-bar is quickly disconnected on connect.