### PR TITLE
feat: distribute via slots

### DIFF
--- a/cosmoz-bottom-bar-view.js
+++ b/cosmoz-bottom-bar-view.js
@@ -3,7 +3,8 @@ import { html } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { ref } from '@neovici/cosmoz-utils/lib/directives/ref';
 import { useBottomBarView } from './lib/use-bottom-bar-view';
-import './cosmoz-bottom-bar';
+import { bottomBarSlots } from './cosmoz-bottom-bar';
+
 
 
 /**
@@ -57,7 +58,7 @@ const CosmozBottomBarView = ({
 			<cosmoz-bottom-bar id="bar" ?active=${ active } bar-height=${ ifDefined(barHeight) } part="bar"
 				@computed-bar-height-changed=${ e => info.computedBarHeight = e.target.computedBarHeight } >
 				<slot></slot>
-				<slot name="extra" slot="extra"></slot>
+				${ bottomBarSlots }
 			</cosmoz-bottom-bar>
 		`;
 };

--- a/cosmoz-bottom-bar.html.js
+++ b/cosmoz-bottom-bar.html.js
@@ -74,7 +74,8 @@ export default html`
             @apply --cosmoz-bottom-bar-toolbar-item-disabled;
         }
 
-        #toolbar ::slotted([hidden]) {
+        #toolbar ::slotted([hidden]),
+        #dropdown ::slotted([hidden]) {
             display: none !important;
         }
 

--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -1,9 +1,12 @@
 /* eslint-disable max-lines */
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import {
+	PolymerElement, html as polymerHtml
+} from '@polymer/polymer/polymer-element.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async';
 import template from './cosmoz-bottom-bar.html.js';
+import { html } from 'haunted';
 
 const
 	BOTTOM_BAR_TOOLBAR_SLOT = 'bottom-bar-toolbar',
@@ -213,37 +216,33 @@ class CosmozBottomBar extends PolymerElement {
 
 	_childrenUpdated(info) {
 		const addedNodes = info.addedNodes.filter(this._isActionNode),
-			removedNodes = info.removedNodes.filter(this._isActionNode);
+			removedNodes = info.removedNodes.filter(this._isActionNode),
+			newNodes = addedNodes.filter(node => !removedNodes.includes(node));
 
 		if (addedNodes.length === 0 && removedNodes.length === 0) {
 			return;
 		}
-		const newNodes = addedNodes.filter(node => removedNodes.indexOf(node) === -1);
 		if (newNodes.length === 0) {
 			return;
 		}
 
-		const toolbarElements = this._getElements().
-				filter(slotEq(BOTTOM_BAR_TOOLBAR_SLOT)),
-			toolbarCount = this.maxToolbarItems - toolbarElements.length;
-
-
 		newNodes.forEach(node => {
 			this._hiddenMutationObserver.observe(node, {
 				attributes: true,
-				attributeFilter: [
-					'hidden'
-				]
+				attributeFilter: ['hidden']
 			});
-			if (node.parentNode !== this) {
-				this.appendChild(node);
-			}
 			this._moveElement(node, false);
 		});
+
+		const toolbarElements = this._getElements().filter(slotEq(BOTTOM_BAR_TOOLBAR_SLOT)),
+			toolbarCount = this.maxToolbarItems - toolbarElements.length;
+
 		if (toolbarCount > 0) {
-			newNodes.filter(node => !node.hidden).slice(0, toolbarCount).
-				forEach(node => this._moveElement(node, true));
+			newNodes
+				.filter(node => !node.hidden).slice(0, toolbarCount)
+				.forEach(node => this._moveElement(node, true));
 		}
+
 		this._debounceLayoutActions();
 	}
 
@@ -423,3 +422,13 @@ class CosmozBottomBar extends PolymerElement {
 }
 
 customElements.define('cosmoz-bottom-bar', CosmozBottomBar);
+
+const tmplt = `
+	<slot name="extra" slot="extra"></slot>
+	<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
+	<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
+`;
+
+export const
+	bottomBarSlots = html([tmplt]),
+	bottomBarSlotsPolymer = polymerHtml([tmplt]);


### PR DESCRIPTION
Moving the assigned nodes from the slot directly to the bottom-bar is not compatible with lit-html.
When lit-html tries to remove the elements it rendered, it will fail to remove the moved DOM, thus
leading to duplicate items in the bottom-bar.

BREAKING CHANGE: If your component allows adding content to the bottom bar via slots, then you have
to also make sure you also export `bottom-bar-toolbar` and `bottom-bar-menu`, otherwise the actions
will not show up.

Fixes #24802 (RM:24802)

Migration guide:

Add this code to every template that exposes the default slot of a cosmoz-bottom-bar.
```
<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
```