### PR TITLE
fix(cosmoz-bottom-bar): correctly sort items with missing data index

### DIFF
--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -273,7 +273,7 @@ class CosmozBottomBar extends PolymerElement {
 		return FlattenedNodesObserver.getFlattenedNodes(this)
 			.filter(this._isActionNode)
 			.filter(element => !element.hidden)
-			.sort((a, b) => a.dataset.index - b.dataset.index);
+			.sort((a, b) => (a.dataset.index ?? 0) - (b.dataset.index ?? 0 ));
 	}
 	/**
 	 * Layout the actions available as buttons or menu items


### PR DESCRIPTION
If some actions are  missing data-index the default 0 should be used.
