### PR TITLE
fix: bar height computation triggers layout reflow

### DIFF
--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -127,18 +127,8 @@ class CosmozBottomBar extends PolymerElement {
 			 */
 			computedBarHeight: {
 				type: Number,
-				computed:
-					'_computeComputedBarHeight(_matchHeightElement, barHeight, _computedBarHeightKicker)',
 				notify: true,
 			},
-
-			/**
-			 * Kicker to make `computedBarHeight` recalculate
-			 */
-			_computedBarHeightKicker: {
-				type: Number,
-			},
-
 			forceOpen: {
 				type: Boolean,
 				value: false,
@@ -211,7 +201,10 @@ class CosmozBottomBar extends PolymerElement {
 			this._debounceLayoutActions(),
 		);
 		this._resizeObserver.observe(this);
-		this._computedBarHeightKicker = 0;
+		this.computedBarHeight = this._computeComputedBarHeight(
+			this._matchHeightElement,
+			this.barHeight,
+		);
 	}
 
 	disconnectedCallback() {
@@ -371,7 +364,10 @@ class CosmozBottomBar extends PolymerElement {
 		if (hidden) {
 			return;
 		}
-		this._computedBarHeightKicker += 1;
+		this.computedBarHeight = this._computeComputedBarHeight(
+			this._matchHeightElement,
+			this.barHeight,
+		);
 	}
 
 	_showHideBottomBar(visible) {

--- a/test/cosmoz-bottom-bar.test.js
+++ b/test/cosmoz-bottom-bar.test.js
@@ -1,6 +1,4 @@
-import {
-	assert, fixture, html, aTimeout
-} from '@open-wc/testing';
+import { assert, fixture, html, aTimeout } from '@open-wc/testing';
 
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer';
 
@@ -8,25 +6,32 @@ import '../cosmoz-bottom-bar.js';
 
 const isElement = ({ nodeType: type }) => type === Node.ELEMENT_NODE;
 
-suite('bottomBarWithoutMenu',	 () => {
+suite('bottomBarWithoutMenu', () => {
 	let bottomBar;
 
 	setup(async () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar style="min-width: 200px; max-width: 200px">
-				<div style="width: 50px; height: 32px; background: red" id="bottomBarWithoutMenuItem" ></div>
+				<div
+					style="width: 50px; height: 32px; background: red"
+					id="bottomBarWithoutMenuItem"
+				></div>
 			</cosmoz-bottom-bar>
 		`);
 		bottomBar._layoutDebouncer.flush();
 	});
 
 	test('button should be placed in toolbar', () => {
-		const item = FlattenedNodesObserver.getFlattenedNodes(bottomBar).find(isElement),
+		const item =
+				FlattenedNodesObserver.getFlattenedNodes(bottomBar).find(isElement),
 			slot = item.getAttribute('slot');
 
 		assert.equal(item.id, 'bottomBarWithoutMenuItem');
 		assert.equal(slot, 'bottom-bar-toolbar');
-		assert.equal(item, FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarToolbar)[0]);
+		assert.equal(
+			item,
+			FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarToolbar)[0],
+		);
 	});
 
 	test('menu button should be hidden', () => {
@@ -40,36 +45,50 @@ suite('bottomBarWithOverflowingButton', () => {
 	setup(async () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar style="min-width: 300px; max-width: 300px">
-				<div style="width: 200px; height: 32px; background: red" id="bottomBarWithOverflowingButtonItem1"></div>
-				<div style="width: 200px; height:32px; background: blue" id="bottomBarWithOverflowingButtonItem2"></div>
+				<div
+					style="width: 200px; height: 32px; background: red"
+					id="bottomBarWithOverflowingButtonItem1"
+				></div>
+				<div
+					style="width: 200px; height:32px; background: blue"
+					id="bottomBarWithOverflowingButtonItem2"
+				></div>
 			</cosmoz-bottom-bar>
 		`);
 		bottomBar._layoutDebouncer.flush();
 	});
 
 	test('First button should be placed in toolbar', () => {
-		const item = FlattenedNodesObserver.getFlattenedNodes(bottomBar).find(isElement),
+		const item =
+				FlattenedNodesObserver.getFlattenedNodes(bottomBar).find(isElement),
 			slot = item.getAttribute('slot');
 
 		assert.equal(slot, 'bottom-bar-toolbar');
 		assert.equal(item.id, 'bottomBarWithOverflowingButtonItem1');
-		assert.equal(item, FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarToolbar)[0]);
-
+		assert.equal(
+			item,
+			FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarToolbar)[0],
+		);
 	});
 
 	test('Second button should be placed in menu', () => {
-		const item = FlattenedNodesObserver.getFlattenedNodes(bottomBar).filter(isElement)[1],
+		const item =
+				FlattenedNodesObserver.getFlattenedNodes(bottomBar).filter(
+					isElement,
+				)[1],
 			slot = item.getAttribute('slot');
 		assert.equal(slot, 'bottom-bar-menu');
 		assert.equal(item.id, 'bottomBarWithOverflowingButtonItem2');
-		assert.equal(item, FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarMenu)[0]);
+		assert.equal(
+			item,
+			FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarMenu)[0],
+		);
 	});
 
 	test('menu button should be visible', () => {
 		bottomBar._layoutDebouncer.flush(); //flush again to update hidden
 		assert.isFalse(bottomBar.$.dropdown.hidden);
 	});
-
 });
 
 suite('bottomBarMaxToolbarItems', () => {
@@ -77,22 +96,41 @@ suite('bottomBarMaxToolbarItems', () => {
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar max-toolbar-items="3" style="min-width:400px; max-width: 400px">
-				<div id="bottomBarMaxToolbarItemsItem1" style="width: 50px; height: 32px; background: red"></div>
-				<div id="bottomBarMaxToolbarItemsItem2" style="width: 50px; height: 32px; background: blue"></div>
-				<div id="bottomBarMaxToolbarItemsItem3" style="width: 50px; height: 32px; background: green"></div>
-				<div id="bottomBarMaxToolbarItemsItem4" style="width: 50px; height: 32px; background: black"></div>
+			<cosmoz-bottom-bar
+				max-toolbar-items="3"
+				style="min-width:400px; max-width: 400px"
+			>
+				<div
+					id="bottomBarMaxToolbarItemsItem1"
+					style="width: 50px; height: 32px; background: red"
+				></div>
+				<div
+					id="bottomBarMaxToolbarItemsItem2"
+					style="width: 50px; height: 32px; background: blue"
+				></div>
+				<div
+					id="bottomBarMaxToolbarItemsItem3"
+					style="width: 50px; height: 32px; background: green"
+				></div>
+				<div
+					id="bottomBarMaxToolbarItemsItem4"
+					style="width: 50px; height: 32px; background: black"
+				></div>
 			</cosmoz-bottom-bar>
 		`);
 		bottomBar._layoutDebouncer.flush();
 	});
 
 	test('Toolbar should not contains more than max-toolbar-items', () => {
-		const toolBarNodes = FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarToolbar),
+		const toolBarNodes = FlattenedNodesObserver.getFlattenedNodes(
+				bottomBar.$.bottomBarToolbar,
+			),
 			item1 = toolBarNodes[0],
 			item2 = toolBarNodes[1],
 			item3 = toolBarNodes[2],
-			item4 = FlattenedNodesObserver.getFlattenedNodes(bottomBar.$.bottomBarMenu)[0];
+			item4 = FlattenedNodesObserver.getFlattenedNodes(
+				bottomBar.$.bottomBarMenu,
+			)[0];
 
 		assert.equal(toolBarNodes.length, 3);
 		assert.equal(item1.id, 'bottomBarMaxToolbarItemsItem1');
@@ -103,19 +141,35 @@ suite('bottomBarMaxToolbarItems', () => {
 });
 
 suite('bottomBarWithHiddenButton', () => {
-	let bottomBar,
-		toolbar,
-		menu;
+	let bottomBar, toolbar, menu;
 
-	const visibleFilter = item => item.offsetWidth > 0 && item.offsetHeight > 0;
+	const visibleFilter = (item) => item.offsetWidth > 0 && item.offsetHeight > 0;
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar active style="min-width:400px; max-width: 410px" max-toolbar-items="3">
-				<div id="bottomBarWithHiddenButtonItem1" style="width: 150px; height: 32px; background: red"></div>
-				<div id="bottomBarWithHiddenButtonItem2" hidden style="width: 150px; height: 32px; background: blue"></div>
-				<div id="bottomBarWithHiddenButtonItem3" style="width: 150px; height: 32px; background: green"></div>
-				<div id="bottomBarWithHiddenButtonItem4" hidden style="width: 150px; height: 32px; background: purple"></div>
+			<cosmoz-bottom-bar
+				active
+				style="min-width:400px; max-width: 410px"
+				max-toolbar-items="3"
+			>
+				<div
+					id="bottomBarWithHiddenButtonItem1"
+					style="width: 150px; height: 32px; background: red"
+				></div>
+				<div
+					id="bottomBarWithHiddenButtonItem2"
+					hidden
+					style="width: 150px; height: 32px; background: blue"
+				></div>
+				<div
+					id="bottomBarWithHiddenButtonItem3"
+					style="width: 150px; height: 32px; background: green"
+				></div>
+				<div
+					id="bottomBarWithHiddenButtonItem4"
+					hidden
+					style="width: 150px; height: 32px; background: purple"
+				></div>
 			</cosmoz-bottom-bar>
 		`);
 		toolbar = bottomBar.$.bottomBarToolbar;
@@ -144,7 +198,7 @@ suite('bottomBarWithHiddenButton', () => {
 			item1 = toolBarNodes[0],
 			menuItems = FlattenedNodesObserver.getFlattenedNodes(menu),
 			item2 = menuItems[0],
-			item3 =	toolBarNodes[1];
+			item3 = toolBarNodes[1];
 
 		assert.equal(item1.id, 'bottomBarWithHiddenButtonItem1');
 		assert.equal(item2.id, 'bottomBarWithHiddenButtonItem2');
@@ -162,27 +216,28 @@ suite('bottomBarWithHiddenButton', () => {
 });
 
 suite('height management', () => {
-	let heightManagementParent,
-		bottomBar;
-
-	setup(async () => {
-		heightManagementParent = await fixture(html`
-			<div id="heightManagementParent" style="min-height: 100px; max-height: 100px">
-				<cosmoz-bottom-bar>
+	const initBar = async ({ matchParent }) => {
+		const r = await fixture(html`
+			<div
+				id="heightManagementParent"
+				style="min-height: 100px; max-height: 100px"
+			>
+				<cosmoz-bottom-bar ?match-parent=${matchParent}>
 					<div style="width: 50px; height: 32px; background: red"></div>
 				</cosmoz-bottom-bar>
 			</div>
 		`);
-		bottomBar = heightManagementParent.querySelector('cosmoz-bottom-bar');
-	});
 
-	test('setting matchParent to true should set bottom-bar height to the height of the parent', () => {
-		bottomBar.matchParent = true;
+		return r.querySelector('cosmoz-bottom-bar');
+	};
+
+	test('setting matchParent to true should set bottom-bar height to the height of the parent', async () => {
+		const bottomBar = await initBar({ matchParent: true });
 		assert.equal(bottomBar.computedBarHeight, 100);
 	});
 
-	test('setting matchParent to false should set bottom-bar height to the height of the bar', () => {
-		bottomBar.matchParent = false;
+	test('setting matchParent to false should set bottom-bar height to the height of the bar', async () => {
+		const bottomBar = await initBar({ matchParent: false });
 		assert.equal(bottomBar.computedBarHeight, bottomBar.barHeight);
 	});
 });
@@ -209,5 +264,4 @@ suite('toggle bottom bar', () => {
 		await aTimeout(330);
 		assert.equal(bottomBar.style.display, '');
 	});
-
 });


### PR DESCRIPTION
Calculate the barHeight directly in the resize observer callback. 