### PR TITLE
fix: change tabindex for action menu buttons + vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
-
 {
-	"eslint.validate": [ "javascript" ],
+	"eslint.validate": ["javascript"],
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -356,7 +356,7 @@ class CosmozBottomBar extends PolymerElement {
 
 	_moveElement(element, toToolbar) {
 		const slot = toToolbar ? BOTTOM_BAR_TOOLBAR_SLOT : BOTTOM_BAR_MENU_SLOT,
-			tabindex = toToolbar ? '0' : '-1';
+			tabindex = '0';
 		element.setAttribute('slot', slot);
 		element.setAttribute('tabindex', tabindex);
 		element.classList.toggle(this.menuClass, !toToolbar);


### PR DESCRIPTION
Change tabindex for action menu buttons as a starting point to make a keyboard shortcut for opening menus + change vscode settings

[AB#14428](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/14428/)