### PR TITLE
fix: collect all actions in dropdown when too narrow

### DIFF
--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import {
 	PolymerElement,
 	html as polymerHtml,
@@ -7,10 +6,10 @@ import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nod
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async';
 import { html } from 'lit-html';
+import { hauntedPolymer } from '@neovici/cosmoz-utils';
 import { useActivity } from '@neovici/cosmoz-utils/keybindings/use-activity';
 import { defaultPlacement } from '@neovici/cosmoz-dropdown';
 import template from './cosmoz-bottom-bar.html.js';
-import { hauntedPolymer } from '@neovici/cosmoz-utils';
 
 const BOTTOM_BAR_TOOLBAR_SLOT = 'bottom-bar-toolbar',
 	BOTTOM_BAR_MENU_SLOT = 'bottom-bar-menu',
@@ -63,11 +62,9 @@ const openActionsMenu = (host) => {
  */
 class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 	static get template() {
-		// eslint-disable-line max-lines-per-function
 		return template;
 	}
 
-	// eslint-disable-next-line max-lines-per-function
 	static get properties() {
 		return {
 			/**
@@ -241,7 +238,7 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 		[...this._nodeObservers, this._hiddenMutationObserver].forEach((e) =>
 			e.disconnect(e),
 		);
-		this._layoutDebouncer?.cancel(); /* eslint-disable-line no-unused-expressions */
+		this._layoutDebouncer?.cancel();
 		this._resizeObserver.unobserve(this);
 	}
 
@@ -336,6 +333,18 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 			...elements.filter((e) => e !== topPriorityAction),
 		];
 	}
+
+	_distribute(hostWidth) {
+		const elements = this._getElements();
+
+		const tooNarrow = hostWidth <= 480,
+			toolbarElements = elements.slice(0, tooNarrow ? 0 : this.maxToolbarItems),
+			menuElements = elements.slice(toolbarElements.length);
+		toolbarElements.forEach((el) => this._moveElement(el, true));
+		menuElements.forEach((el) => this._moveElement(el));
+		this._setHasMenuItems(menuElements.length > 0);
+	}
+
 	/**
 	 * Layout the actions available as buttons or menu items
 	 *
@@ -357,7 +366,6 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 	 * @returns {void}
 	 */
 	_layoutActions() {
-		// eslint-disable-line max-statements
 		const elements = this._getElements(),
 			hasActions = elements.length > 0 || this.hasExtraItems;
 		this._setHasActions(hasActions);
@@ -367,11 +375,7 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 			return this._setHasMenuItems(false);
 		}
 
-		const toolbarElements = elements.slice(0, this.maxToolbarItems),
-			menuElements = elements.slice(toolbarElements.length);
-		toolbarElements.forEach((el) => this._moveElement(el, true));
-		menuElements.forEach((el) => this._moveElement(el));
-		this._setHasMenuItems(menuElements.length > 0);
+		this._distribute(this.getBoundingClientRect().width);
 	}
 
 	_moveElement(element, toToolbar) {
@@ -395,6 +399,7 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 			this._matchHeightElement,
 			this.barHeight,
 		);
+		this._distribute(entry.contentRect?.width);
 	}
 
 	_showHideBottomBar(visible) {

--- a/test/cosmoz-bottom-bar.test.js
+++ b/test/cosmoz-bottom-bar.test.js
@@ -11,7 +11,7 @@ suite('bottomBarWithoutMenu', () => {
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar style="min-width: 200px; max-width: 200px">
+			<cosmoz-bottom-bar style="min-width: 500px; max-width: 500px">
 				<div
 					style="width: 50px; height: 32px; background: red"
 					id="bottomBarWithoutMenuItem"
@@ -44,7 +44,7 @@ suite('bottomBarWithOverflowingButton', () => {
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar style="min-width: 300px; max-width: 300px">
+			<cosmoz-bottom-bar style="min-width: 500px; max-width: 500px">
 				<div
 					style="width: 200px; height: 32px; background: red"
 					id="bottomBarWithOverflowingButtonItem1"
@@ -98,7 +98,7 @@ suite('bottomBarMaxToolbarItems', () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar
 				max-toolbar-items="3"
-				style="min-width:400px; max-width: 400px"
+				style="min-width: 500px; max-width: 500px"
 			>
 				<div
 					id="bottomBarMaxToolbarItemsItem1"
@@ -149,7 +149,7 @@ suite('bottomBarWithHiddenButton', () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar
 				active
-				style="min-width:400px; max-width: 410px"
+				style="min-width: 500px; max-width: 510px"
 				max-toolbar-items="3"
 			>
 				<div


### PR DESCRIPTION
Make actions outside of dropdown menu go inside when bottom-bar is too narrow.

[AB#17737](https://dev.azure.com/neovici/Cosmoz3/_backlogs/backlog/UX/Stories/?workitem=17737)