### PR TITLE
Update bottom bar to use pion

### DIFF
--- a/src/cosmoz-bottom-bar-next.js
+++ b/src/cosmoz-bottom-bar-next.js
@@ -154,7 +154,7 @@ const CosmozBottomBar = ({ active = false, maxToolbarItems = 1 }) => {
 	};
 
 	return html`<div id="bar" part="bar">
-			<div id="info"><slot name="info"></slot></div>
+			<div id="info" part="info"><slot name="info"></slot></div>
 			<slot
 				id="bottomBarToolbar"
 				name="bottom-bar-toolbar"

--- a/src/cosmoz-bottom-bar-next.js
+++ b/src/cosmoz-bottom-bar-next.js
@@ -5,7 +5,7 @@ import { component, useLayoutEffect } from '@pionjs/pion';
 import { useHost } from '@neovici/cosmoz-utils/hooks/use-host';
 import { style } from './cosmoz-bottom-bar-next.style.js';
 import { toggleSize } from '@neovici/cosmoz-collapse/toggle';
-import { sheet } from '@neovici/cosmoz-utils';
+import { useActivity } from '@neovici/cosmoz-utils/keybindings/use-activity';
 import '@neovici/cosmoz-dropdown';
 
 const BOTTOM_BAR_TOOLBAR_SLOT = 'bottom-bar-toolbar';
@@ -120,6 +120,20 @@ const _layoutActions = (host, maxToolbarItems) => {
 	host.toggleAttribute('has-menu-items', menuElements.length > 0);
 };
 
+export const openMenu = Symbol('openMenu');
+
+const openActionsMenu = (host) => {
+	const dropdown = host.shadowRoot.querySelector('#dropdown');
+
+	if (dropdown.hasAttribute('hidden')) return;
+
+	//TODO: Clean up when open function is implemented for cosmoz-dropdown-menu
+	dropdown.shadowRoot
+		.querySelector('cosmoz-dropdown')
+		.shadowRoot.getElementById('dropdownButton')
+		.click();
+};
+
 /**
  * `<cosmoz-bottom-bar>` is a horizontal responsive bottom toolbar containing items that
  * can be used for actions.
@@ -142,6 +156,16 @@ const _layoutActions = (host, maxToolbarItems) => {
 // eslint-disable-next-line max-statements
 const CosmozBottomBar = ({ active = false, maxToolbarItems = 1 }) => {
 	const host = useHost();
+
+	useActivity(
+		{
+			activity: openMenu,
+			callback: () => openActionsMenu(host),
+			check: () => host.active && !host.hasAttribute('hide-actions'),
+			element: () => host.shadowRoot.querySelector('#dropdown'),
+		},
+		[host.active],
+	);
 
 	const toggle = toggleSize('height');
 
@@ -203,6 +227,6 @@ customElements.define(
 	'cosmoz-bottom-bar-next',
 	component(CosmozBottomBar, {
 		observedAttributes: ['active'],
-		styleSheets: [sheet(style)],
+		styleSheets: [style],
 	}),
 );

--- a/src/cosmoz-bottom-bar-next.style.js
+++ b/src/cosmoz-bottom-bar-next.style.js
@@ -51,7 +51,7 @@ export const style = css`
 		margin-right: auto;
 		white-space: nowrap;
 	}
-	#bottomBarToolbar::slotted(:not(slot)) {
+	#bottomBarToolbar::slotted(:not(slot):not([unstyled])) {
 		margin: 0 0.29em;
 		min-width: 40px;
 		min-height: 40px;

--- a/src/cosmoz-bottom-bar-next.style.js
+++ b/src/cosmoz-bottom-bar-next.style.js
@@ -17,6 +17,7 @@ export const style = css`
 			rgba(230, 230, 230, 0.8)
 		);
 		box-shadow: var(--cosmoz-bottom-bar-shadow, none);
+		z-index: 1;
 
 		--cosmoz-dropdown-anchor-spacing: 12px 6px;
 		--paper-button: {

--- a/stories/cosmoz-bottom-bar.stories.ts
+++ b/stories/cosmoz-bottom-bar.stories.ts
@@ -19,8 +19,8 @@ const CosmozBottomBarTemplate = ({
 	hideButton3?: boolean;
 	hideButton4?: boolean;
 	hideButton5?: boolean;
-}) => {
-	return html`<cosmoz-bottom-bar-next
+}) => html`
+	<cosmoz-bottom-bar-next
 		id="bottomBar"
 		?active=${active}
 		.maxToolbarItems=${maxToolbarItems}
@@ -35,8 +35,8 @@ const CosmozBottomBarTemplate = ({
 			>Button 4</paper-button
 		>
 		<paper-button ?hidden=${hideButton5}>Button 5</paper-button>
-	</cosmoz-bottom-bar-next>`;
-};
+	</cosmoz-bottom-bar-next>
+`;
 
 const CosmozBottomBarEmptyTemplate = ({
 	active,
@@ -44,15 +44,15 @@ const CosmozBottomBarEmptyTemplate = ({
 }: {
 	active?: boolean;
 	maxToolbarItems?: number;
-}) => {
-	return html`<cosmoz-bottom-bar-next
+}) => html`
+	<cosmoz-bottom-bar-next
 		id="bottomBar"
 		?active=${active}
 		.maxToolbarItems=${maxToolbarItems}
 	>
 		<span slot="info">Bottom bar demo</span>
-	</cosmoz-bottom-bar-next>`;
-};
+	</cosmoz-bottom-bar-next>
+`;
 
 const meta: Meta = {
 	title: 'Cosmoz Bottom Bar',


### PR DESCRIPTION
[AB#18581](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/18581)

Migrated following changes from releases:
1. [7.2.2](https://github.com/neovici/cosmoz-bottom-bar/compare/v7.2.1...v7.2.2): add z-index to make sure bottom-bar is above views content 
2. [7.3.0](https://github.com/neovici/cosmoz-bottom-bar/compare/v7.2.2...v7.3.0): support unstyled attribute
3. [7.4.0](https://github.com/neovici/cosmoz-bottom-bar/compare/v7.3.0...v7.4.0): add a info part
4. [7.5.0](https://github.com/neovici/cosmoz-bottom-bar/compare/v7.4.0...v7.5.0): open actions dropdown on useActivity callback 

Not sure if [this](https://github.com/neovici/cosmoz-bottom-bar/commit/87c5c78e8f8b86c7b5bc7cf8781137e6618de93f#diff-98a59bb076396dd48b54017fbb40f73efdc98863193f73ea027feea30ddc42a3R190) change is needed in the next version. 

Demo: https://jam.dev/c/ce473434-a330-4abc-84db-59501e1d3da8