### PR TITLE
fix: revert changes of collecting actions in dropdown

### DIFF
--- a/cosmoz-bottom-bar.html.js
+++ b/cosmoz-bottom-bar.html.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import '@neovici/cosmoz-dropdown';
 import { html } from '@polymer/polymer/lib/utils/html-tag';
 

--- a/cosmoz-bottom-bar.js
+++ b/cosmoz-bottom-bar.js
@@ -238,7 +238,6 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 		[...this._nodeObservers, this._hiddenMutationObserver].forEach((e) =>
 			e.disconnect(e),
 		);
-		this._layoutDebouncer?.cancel();
 		this._resizeObserver.unobserve(this);
 	}
 
@@ -334,17 +333,6 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 		];
 	}
 
-	_distribute(hostWidth) {
-		const elements = this._getElements();
-
-		const tooNarrow = hostWidth <= 480,
-			toolbarElements = elements.slice(0, tooNarrow ? 0 : this.maxToolbarItems),
-			menuElements = elements.slice(toolbarElements.length);
-		toolbarElements.forEach((el) => this._moveElement(el, true));
-		menuElements.forEach((el) => this._moveElement(el));
-		this._setHasMenuItems(menuElements.length > 0);
-	}
-
 	/**
 	 * Layout the actions available as buttons or menu items
 	 *
@@ -375,7 +363,11 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 			return this._setHasMenuItems(false);
 		}
 
-		this._distribute(this.getBoundingClientRect().width);
+		const toolbarElements = elements.slice(0, this.maxToolbarItems),
+			menuElements = elements.slice(toolbarElements.length);
+		toolbarElements.forEach((el) => this._moveElement(el, true));
+		menuElements.forEach((el) => this._moveElement(el));
+		this._setHasMenuItems(menuElements.length > 0);
 	}
 
 	_moveElement(element, toToolbar) {
@@ -399,7 +391,6 @@ class CosmozBottomBar extends hauntedPolymer(useBottomBar)(PolymerElement) {
 			this._matchHeightElement,
 			this.barHeight,
 		);
-		this._distribute(entry.contentRect?.width);
 	}
 
 	_showHideBottomBar(visible) {

--- a/test/cosmoz-bottom-bar.test.js
+++ b/test/cosmoz-bottom-bar.test.js
@@ -11,7 +11,7 @@ suite('bottomBarWithoutMenu', () => {
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar style="min-width: 500px; max-width: 500px">
+			<cosmoz-bottom-bar style="min-width: 200px; max-width: 200px">
 				<div
 					style="width: 50px; height: 32px; background: red"
 					id="bottomBarWithoutMenuItem"
@@ -44,7 +44,7 @@ suite('bottomBarWithOverflowingButton', () => {
 
 	setup(async () => {
 		bottomBar = await fixture(html`
-			<cosmoz-bottom-bar style="min-width: 500px; max-width: 500px">
+			<cosmoz-bottom-bar style="min-width: 300px; max-width: 300px">
 				<div
 					style="width: 200px; height: 32px; background: red"
 					id="bottomBarWithOverflowingButtonItem1"
@@ -98,7 +98,7 @@ suite('bottomBarMaxToolbarItems', () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar
 				max-toolbar-items="3"
-				style="min-width: 500px; max-width: 500px"
+				style="min-width: 400px; max-width: 400px"
 			>
 				<div
 					id="bottomBarMaxToolbarItemsItem1"
@@ -149,7 +149,7 @@ suite('bottomBarWithHiddenButton', () => {
 		bottomBar = await fixture(html`
 			<cosmoz-bottom-bar
 				active
-				style="min-width: 500px; max-width: 510px"
+				style="min-width: 400px; max-width: 410px"
 				max-toolbar-items="3"
 			>
 				<div


### PR DESCRIPTION
Revert changes made in [PR#166](https://github.com/Neovici/cosmoz-bottom-bar/pull/166)

Ref: [https://neovici.slack.com/archives/CCU2R1Q3Y/p1737370518741149](https://neovici.slack.com/archives/CCU2R1Q3Y/p1737370518741149)
[AB#17737](https://dev.azure.com/neovici/Cosmoz3/_backlogs/backlog/UX/Stories/?workitem=17737)