### PR TITLE
fix: simplify code and handle disconnect properly

### DIFF
--- a/src/cosmoz-bottom-bar.ts
+++ b/src/cosmoz-bottom-bar.ts
@@ -205,7 +205,6 @@ const useMenuButtons = (host: Host) => {
 			? buttonStates.visible.size
 			: allButtons.length,
 	);
-	
 
 	useEffect(() => {
 		processedButtons.forEach(({ element, priority }, i) => {
@@ -216,7 +215,14 @@ const useMenuButtons = (host: Host) => {
 	}, [processedButtons, toolbarLimit]);
 
 	const menuButtons = useMemo(
-		() => processedButtons.slice(toolbarLimit),
+		() =>
+			processedButtons
+				.slice(toolbarLimit)
+				.sort(
+					(a, b) =>
+						b.element.compareDocumentPosition(a.element) -
+						a.element.compareDocumentPosition(b.element),
+				),
 		[processedButtons, toolbarLimit],
 	);
 

--- a/src/overflow.ts
+++ b/src/overflow.ts
@@ -96,7 +96,7 @@ class OverflowDirective extends AsyncDirective {
 		this.teardownObserver();
 	}
 
-	reconnected(): void {
+	reconnected() {
 		this.setupListener();
 		this.setupObserver();
 	}

--- a/src/overflow.ts
+++ b/src/overflow.ts
@@ -1,6 +1,6 @@
 import { AttributePart, noChange } from 'lit-html';
 import { AsyncDirective } from 'lit-html/async-directive.js';
-import { directive, DirectiveResult, PartInfo } from 'lit-html/directive.js';
+import { directive, DirectiveResult } from 'lit-html/directive.js';
 
 type OnOverflow = (opts: {
 	visible: Set<HTMLElement>;
@@ -17,17 +17,52 @@ const check = (part: AttributePart) => {
 	}
 };
 
+const setupObserver = (slot: HTMLSlotElement, onOverflow: OnOverflow) => {
+	const visible: Set<HTMLElement> = new Set();
+	const overflowing: Set<HTMLElement> = new Set();
+
+	const observer: IntersectionObserver = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				const el = entry.target as HTMLElement;
+
+				if (entry.intersectionRatio === 1) {
+					visible.add(el);
+					overflowing.delete(el);
+				} else if (isEntryHidden(entry)) {
+					visible.delete(el);
+					overflowing.delete(el);
+				} else {
+					visible.delete(el);
+					overflowing.add(el);
+				}
+			});
+			onOverflow({ visible, overflowing });
+		},
+		{ root: slot.parentElement, threshold: 1 },
+	);
+
+	const observe = () => {
+		const elements = Array.from(slot.assignedElements()) as HTMLElement[];
+		for (const c of elements) {
+			observer.observe(c);
+		}
+	};
+
+	observe();
+
+	slot.addEventListener('slotchange', observe);
+
+	return () => {
+		slot.removeEventListener('slotchange', observe);
+		observer.disconnect();
+	};
+};
+
 class OverflowDirective extends AsyncDirective {
 	observer?: IntersectionObserver;
 	slot?: HTMLSlotElement;
-	onOverflow?: OnOverflow;
 	cleanup?: () => void;
-
-	constructor(part: PartInfo) {
-		super(part);
-
-		this.setupObserver = this.setupObserver.bind(this);
-	}
 
 	render() {
 		return noChange;
@@ -35,7 +70,6 @@ class OverflowDirective extends AsyncDirective {
 
 	update(part: AttributePart, [onOverflow]: [OnOverflow]) {
 		check(part);
-		this.onOverflow = onOverflow;
 
 		const hasChanged = this.slot !== part.element;
 		if (hasChanged) {
@@ -44,63 +78,10 @@ class OverflowDirective extends AsyncDirective {
 				this.cleanup = undefined;
 			}
 			this.slot = part.element as HTMLSlotElement;
-			this.setupObserver();
+			this.cleanup = setupObserver(this.slot, onOverflow);
 		}
 
 		return noChange;
-	}
-
-	setupObserver() {
-		if (!this.slot || !this.onOverflow) return;
-
-		const visible: Set<HTMLElement> = new Set();
-		const overflowing: Set<HTMLElement> = new Set();
-
-		this.observer = new IntersectionObserver(
-			(entries) => {
-				entries.forEach((entry) => {
-					const el = entry.target as HTMLElement;
-
-					if (entry.intersectionRatio === 1) {
-						visible.add(el);
-						overflowing.delete(el);
-					} else if (isEntryHidden(entry)) {
-						visible.delete(el);
-						overflowing.delete(el);
-					} else {
-						visible.delete(el);
-						overflowing.add(el);
-					}
-				});
-
-				this.onOverflow!({ visible, overflowing });
-			},
-			{ root: this.slot.parentElement, threshold: 1 },
-		);
-
-		const observe = () => {
-			if (!this.observer || !this.slot) return;
-			const elements = Array.from(
-				this.slot.assignedElements(),
-			) as HTMLElement[];
-			for (const c of elements) {
-				this.observer.observe(c);
-			}
-		};
-
-		observe();
-
-		this.slot.addEventListener('slotchange', observe);
-
-		this.cleanup = () => {
-			if (this.slot) {
-				this.slot.removeEventListener('slotchange', observe);
-			}
-			if (this.observer) {
-				this.observer.disconnect();
-				this.observer = undefined;
-			}
-		};
 	}
 }
 

--- a/stories/cosmoz-bottom-bar.stories.ts
+++ b/stories/cosmoz-bottom-bar.stories.ts
@@ -1,54 +1,49 @@
-/* eslint-disable no-console */
+/* eslint-disable no-alert */
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import '../src/cosmoz-bottom-bar';
 import '@polymer/paper-button/paper-button.js';
 import { component, useState } from '@pionjs/pion';
 import { map } from 'lit-html/directives/map.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 interface CosmozBottomBarStoryProps {
 	active?: boolean;
 	maxToolbarItems?: number;
 }
 
-const CosmozBottomBarStory = ({
-	active,
-	maxToolbarItems,
-}: {
-	active?: boolean;
-	maxToolbarItems?: number;
-}) => {
+const CosmozBottomBarStory = (
+	host: HTMLElement & CosmozBottomBarStoryProps,
+) => {
+	const { active, maxToolbarItems } = host;
 	const [inputValue, setInputValue] = useState<string>('');
 	const [buttons, setButtons] = useState<
 		{
 			onClick: () => void;
-			priority: number;
+			priority?: number;
 			text: string;
 		}[]
 	>([
 		{
-			onClick: () => console.log('!!Button 1 clicked'),
-			priority: 1,
+			onClick: () => alert('!!Button 1 clicked'),
+			priority: 10,
 			text: 'Button 1',
 		},
 		{
-			onClick: () => console.log('!!Button 2 clicked'),
-			priority: 2,
+			onClick: () => alert('!!Button 2 clicked'),
 			text: 'Button 2',
 		},
 		{
-			onClick: () => console.log('!!Button 3 clicked'),
-			priority: 3,
+			onClick: () => alert('!!Button 3 clicked'),
 			text: 'Button 3',
 		},
 		{
-			onClick: () => console.log('!!Button 4 clicked'),
-			priority: 4,
+			onClick: () => alert('!!Button 4 clicked'),
+			priority: 5,
 			text: 'Button 4',
 		},
 		{
-			onClick: () => console.log('!!Button 5 clicked'),
-			priority: 5,
+			onClick: () => alert('!!Button 5 clicked'),
 			text: 'Button 5',
 		},
 	]);
@@ -66,12 +61,17 @@ const CosmozBottomBarStory = ({
 		setButtons([
 			...buttons,
 			{
-				onClick: () => console.log('!!Button ' + inputValue + ' clicked'),
+				onClick: () => alert('!!Button ' + inputValue + ' clicked'),
 				priority: +inputValue,
 				text: 'Button ' + inputValue,
 			},
 		]);
 		setInputValue('');
+	};
+
+	const reconnect = () => {
+		const node = host.shadowRoot!.querySelector('cosmoz-bottom-bar')!;
+		host.shadowRoot!.appendChild(node);
 	};
 
 	return html`
@@ -83,6 +83,7 @@ const CosmozBottomBarStory = ({
 			@keypress=${(e: KeyboardEvent) => e.key === 'Enter' && addButton()}
 		/>
 		<paper-button @click=${addButton}>Add btn</paper-button>
+		<paper-button @click=${reconnect}>Test reconnect</paper-button>
 
 		<cosmoz-bottom-bar
 			id="bottomBar"
@@ -96,7 +97,7 @@ const CosmozBottomBarStory = ({
 					html`<paper-button
 						slot="bottom-bar-toolbar"
 						@click=${btn.onClick}
-						data-priority=${btn.priority}
+						data-priority=${ifDefined(btn.priority)}
 						>${btn.text}</paper-button
 					>`,
 			)}

--- a/stories/cosmoz-bottom-bar.stories.ts
+++ b/stories/cosmoz-bottom-bar.stories.ts
@@ -3,13 +3,24 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit-html';
 import '../src/cosmoz-bottom-bar';
 import '@polymer/paper-button/paper-button.js';
-import { component, useState } from '@pionjs/pion';
+import { component, useEffect, useState } from '@pionjs/pion';
 import { map } from 'lit-html/directives/map.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 interface CosmozBottomBarStoryProps {
 	active?: boolean;
 	maxToolbarItems?: number;
+}
+
+function shuffleArray<T>(array: T[]): T[] {
+	const shuffled = [...array];
+
+	for (let i = shuffled.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+	}
+
+	return shuffled;
 }
 
 const CosmozBottomBarStory = (
@@ -23,50 +34,69 @@ const CosmozBottomBarStory = (
 			priority?: number;
 			text: string;
 		}[]
-	>([
-		{
-			onClick: () => alert('!!Button 1 clicked'),
-			priority: 10,
-			text: 'Button 1',
-		},
-		{
-			onClick: () => alert('!!Button 2 clicked'),
-			text: 'Button 2',
-		},
-		{
-			onClick: () => alert('!!Button 3 clicked'),
-			text: 'Button 3',
-		},
-		{
-			onClick: () => alert('!!Button 4 clicked'),
-			priority: 5,
-			text: 'Button 4',
-		},
-		{
-			onClick: () => alert('!!Button 5 clicked'),
-			text: 'Button 5',
-		},
-	]);
+	>(
+		shuffleArray(
+			[
+				{
+					onClick: () => alert('!!Button 1 clicked'),
+					priority: 10,
+					text: 'Button 1',
+				},
+				{
+					onClick: () => alert('!!Button 2 clicked'),
+					text: 'Button 2',
+				},
+				{
+					onClick: () => alert('!!Button 3 clicked'),
+					text: 'Button 3',
+				},
+				{
+					onClick: () => alert('!!Button 4 clicked'),
+					priority: 5,
+					text: 'Button 4',
+				},
+				{
+					onClick: () => alert('!!Button 5 clicked'),
+					text: 'Button 5',
+				},
+			].concat(
+				...Array.from({ length: 100 }, (_, i) => {
+					const randomNum = i + 6;
+					return {
+						onClick: () => alert('!!Button ' + randomNum + ' clicked'),
+						text: 'Button ' + randomNum,
+						priority: randomNum,
+					};
+				}),
+			),
+		),
+	);
+
+	useEffect(() => {
+		const domOrder = buttons.map((btn, i) => ({ i, prio: btn.priority ?? 0 }));
+
+		console.table(domOrder);
+	}, []);
 
 	const handleInput = (e: InputEvent) => {
 		const target = e.target as HTMLInputElement;
 		setInputValue(target.value);
 	};
 
-	const addButton = () => {
-		if (!inputValue) {
-			return;
-		}
-
+	const addButton = (priority: string | undefined) => {
+		const prio = priority ? priority.trim() : '';
 		setButtons([
 			...buttons,
 			{
-				onClick: () => alert('!!Button ' + inputValue + ' clicked'),
-				priority: +inputValue,
-				text: 'Button ' + inputValue,
+				onClick: () => alert('!!Button ' + prio + ' clicked'),
+				priority: prio ? +prio : undefined,
+				text: 'Button ' + prio,
 			},
 		]);
-		setInputValue('');
+
+		if (priority) {
+			setInputValue('');
+		}
 	};
 
 	const reconnect = () => {
@@ -80,9 +110,13 @@ const CosmozBottomBarStory = (
 			placeholder="priority"
 			type="number"
 			@input=${handleInput}
-			@keypress=${(e: KeyboardEvent) => e.key === 'Enter' && addButton()}
+			@keypress=${(e: KeyboardEvent) =>
+				e.key === 'Enter' && addButton(inputValue)}
 		/>
-		<paper-button @click=${addButton}>Add btn</paper-button>
+		<paper-button @click=${() => addButton(inputValue)}>Add btn</paper-button>
+		<paper-button @click=${() => addButton(undefined)}
+			>Add noprio btn</paper-button
+		>
 		<paper-button @click=${reconnect}>Test reconnect</paper-button>
 
 		<cosmoz-bottom-bar


### PR DESCRIPTION
* separated the calculateDistribution function in a number of effects and memos because it's name was a lie: it does more than "calculate the distribution";
* renamed visibleElements to visible and overflownElements to overflowing and changed the callback signature so it can simply be a state setter;
* grouped the related functionality and extracted the `useMenuButtons` hook to clean up the main hook
* simplified the calculateDistribution code a little bit by removing the need for a second call to .map
* added a button to test the disconnect/reconnect and made sure to also clean up the slotchange handler