### PR TITLE
fix: add missing changeset script for CI publish

### DIFF
--- a/.changeset/short-apes-greet.md
+++ b/.changeset/short-apes-greet.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-bottom-bar': patch
+---
+
+Add missing `changeset` npm script so release workflow can publish successfully.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "lint": "tsc && eslint --cache .",
     "build": "tsc -p tsconfig.build.json",
+    "changeset": "changeset",
     "check:duplicates": "check-duplicate-components",
     "start": "npm run storybook:start",
     "test": "wtr --coverage",


### PR DESCRIPTION
The foundry CI workflow runs `npm run changeset publish`, but the `changeset` script was missing in package.json. This caused the release from PR #399 to fail on the publish step. Adding `"changeset": "changeset"` to scripts.